### PR TITLE
로그인 처리를 위한 authResolver 등록

### DIFF
--- a/src/main/java/com/challenger/challengerbe/config/WebConfig.java
+++ b/src/main/java/com/challenger/challengerbe/config/WebConfig.java
@@ -1,0 +1,43 @@
+package com.challenger.challengerbe.config;
+
+import com.challenger.challengerbe.auth.login.AuthRedirectArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+
+/**
+ * packageName    : com.challenger.challengerbe.config
+ * fileName       : WebConfig
+ * author         : jongh
+ * date           : 2024-09-11
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-09-11           jongh          최초 생성
+ */
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthRedirectArgumentResolver authRedirectArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authRedirectArgumentResolver);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("Authorization", "Content-Type", "Bearer", "credentials")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}

--- a/src/main/java/com/challenger/challengerbe/modules/question/controller/QuestionController.java
+++ b/src/main/java/com/challenger/challengerbe/modules/question/controller/QuestionController.java
@@ -1,11 +1,14 @@
 package com.challenger.challengerbe.modules.question.controller;
 
+import com.challenger.challengerbe.auth.login.AuthInfo;
 import com.challenger.challengerbe.modules.question.dto.QuestionCreateRequest;
 import com.challenger.challengerbe.modules.question.service.QuestionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 2024-09-10           jongh          최초 생성
  */
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/questions")
 @RequiredArgsConstructor
@@ -31,10 +35,18 @@ public class QuestionController {
     private final QuestionService questionService;
 
     @PostMapping
-    public ResponseEntity<Long> createQuestion(@Valid @RequestBody QuestionCreateRequest request) {
+    public ResponseEntity<Long> createQuestion(@Valid @RequestBody QuestionCreateRequest request, @AuthInfo String userIdk) {
         Long response = questionService.insertQuestion(request);
+        log.info("userIdk : " + userIdk);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<String> testAuthInfo(@AuthInfo String userIdk) {
+        log.info("userIdk : " + userIdk);
+
+        return ResponseEntity.ok(userIdk);
     }
 
 


### PR DESCRIPTION
@AuthInfo 어노테이션 사용을 위한 Resolver를 등록하였습니다.

postman 요청

![image](https://github.com/user-attachments/assets/70a7125d-3900-4afe-87f9-e8793ad8ab9f)

controller 테스트 코드

![image](https://github.com/user-attachments/assets/143b1ec1-73e6-40ef-bcd6-8cca7ff525d8)

log 결과

![image](https://github.com/user-attachments/assets/d53346d6-8c30-4272-b2d0-18629da75c33)