### PR TITLE
이미지 파일 링크 생성 API 추가 및 랜딩 페이지 챌린지 목록 조회 수정

### DIFF
--- a/src/main/java/com/challenger/challengerbe/cms/file/CmsFileController.java
+++ b/src/main/java/com/challenger/challengerbe/cms/file/CmsFileController.java
@@ -1,0 +1,77 @@
+package com.challenger.challengerbe.cms.file;
+
+import com.challenger.challengerbe.cms.file.domain.CmsFile;
+import com.challenger.challengerbe.cms.file.dto.CmsFileDto;
+import com.challenger.challengerbe.cms.file.service.CmsFileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.beans.Encoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+/**
+ * packageName    : com.challenger.challengerbe.cms.file
+ * fileName       : CmsFileController
+ * author         : rhkdg
+ * date           : 2024-09-12
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-09-12        rhkdg       최초 생성
+ */
+@Tag(name = "CMS 파일 처리 컨트롤러")
+@RestController
+@RequiredArgsConstructor
+public class CmsFileController {
+
+    private final CmsFileService cmsFileService;
+
+    @Value("${globals.upload.path}")
+    private String uploadPath;
+
+    @Operation(summary = "이미지 링크 파일 생성 API")
+    @Parameter(name = "idx", description = "파일 일련번호에 해당")
+    @GetMapping(value = "/cms/file/image/link")
+    public ResponseEntity<?> convertImage(@RequestParam("idx") Long idx) throws Exception {
+
+        CmsFileDto cmsFileVO = new CmsFileDto();
+        cmsFileVO.setIdx(idx);
+        cmsFileVO = cmsFileService.selectCmsFile(cmsFileVO);
+
+        if(cmsFileVO == null) {
+            return ResponseEntity.notFound().build();
+        }
+        System.out.println(uploadPath+cmsFileVO.getSaveFilePath());
+        Path filePath = Paths.get(uploadPath+cmsFileVO.getSaveFilePath()).resolve(cmsFileVO.getSaveFileName()).normalize();
+        Resource resource = new UrlResource(filePath.toUri());
+
+        // 파일이 존재하고, 읽을 수 있는지 확인합니다.
+        if (resource.exists() && resource.isReadable()) {
+            // 이미지의 Content-Type을 설정합니다.
+            String contentType = "image/jpeg"; // 필요시 다른 타입 설정
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(contentType))
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + URLEncoder.encode(Objects.requireNonNull(resource.getFilename()),StandardCharsets.UTF_8) + "\"")
+                    .body(resource);
+        }else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/src/main/java/com/challenger/challengerbe/modules/challenge/dto/ChallengeSummaryResponse.java
+++ b/src/main/java/com/challenger/challengerbe/modules/challenge/dto/ChallengeSummaryResponse.java
@@ -44,7 +44,7 @@ public record ChallengeSummaryResponse(
         /**비고*/
          String remark,
 
-         String file,
+         Long fileIdx,
 
          Long joinCnt,
 

--- a/src/main/java/com/challenger/challengerbe/modules/challenge/repository/impl/ChallengeCtRepositoryImpl.java
+++ b/src/main/java/com/challenger/challengerbe/modules/challenge/repository/impl/ChallengeCtRepositoryImpl.java
@@ -14,10 +14,12 @@ import com.challenger.challengerbe.modules.challenge.repository.ChallengeCtRepos
 import com.challenger.challengerbe.modules.user.domain.QUser;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.DateTemplate;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import io.micrometer.common.util.StringUtils;
 import jakarta.persistence.EntityManager;
@@ -98,21 +100,24 @@ public class ChallengeCtRepositoryImpl extends BaseAbstractRepositoryImpl implem
                         qChallenge.successCnt,
                         qChallenge.title,
                         qChallenge.remark,
-                        qCmsFile.saveFilePath.concat("/").concat(qCmsFile.saveFileName),
-                        qChallengeUser.count(),
+                        qCmsFile.idx,
+                        ExpressionUtils.as(
+                                JPAExpressions.select(qChallengeUser.count())
+                                        .from(qChallengeUser)
+                                        .where(qChallenge.idx.eq(qChallengeUser.challenge.idx).and(qChallengeUser.user.idk.ne(searchDto.getIdk())))
+
+                        ,"joinCnt"),
                         qChallenge.createDate,
                         qChallenge.modifyDate
                 )
         ).from(qChallenge)
-                .leftJoin(qChallengeUser).on(qChallengeUser.challenge.idx.eq(qChallenge.idx).and(
-                        qChallengeUser.user.idk.ne(searchDto.getIdk())
-                ))
                 .leftJoin(qPublicCode).on(qChallenge.publicCode.pubCd.eq(qPublicCode.pubCd))
                 .leftJoin(qUser).on(qChallenge.user.idk.eq(qUser.idk))
                 .leftJoin(qCmsFile)
                 .on(qCmsFile.parentIdx.eq(qChallenge.idx.stringValue())
                         .and(qCmsFile.uploadCode.eq("upload.challenge.create")))
                 .where(commonQuery(searchDto))
+                .orderBy(qChallenge.idx.desc())
                 .offset(searchDto.getPageable().getOffset())
                 .limit(searchDto.getPageable().getPageSize())
                 .fetch();
@@ -141,20 +146,23 @@ public class ChallengeCtRepositoryImpl extends BaseAbstractRepositoryImpl implem
                                 qChallenge.successCnt,
                                 qChallenge.title,
                                 qChallenge.remark,
-                                qCmsFile.saveFilePath.concat("/").concat(qCmsFile.saveFileName),
-                                qChallengeUser.count(),
+                                qCmsFile.idx,
+                                ExpressionUtils.as(
+                                        JPAExpressions.select(qChallengeUser.count())
+                                                .from(qChallengeUser)
+                                                .where(qChallenge.idx.eq(qChallengeUser.challenge.idx).and(qChallengeUser.user.idk.ne(searchDto.getIdk())))
+
+                                        ,"joinCnt"),
                                 qChallenge.createDate,
                                 qChallenge.modifyDate
                         )
                 ).from(qChallenge)
-                .leftJoin(qChallengeUser).on(qChallengeUser.challenge.idx.eq(qChallenge.idx).and(
-                        qChallengeUser.user.idk.ne(searchDto.getIdk())
-                ))
                 .leftJoin(qPublicCode).on(qChallenge.publicCode.pubCd.eq(qPublicCode.pubCd))
                 .leftJoin(qUser).on(qChallenge.user.idk.eq(qUser.idk))
                 .leftJoin(qCmsFile).on(qCmsFile.parentIdx.eq(qChallenge.idx.stringValue())
                         .and(qCmsFile.uploadCode.eq("upload.challenge.create")))
                 .where(commonQuery(searchDto))
+                .orderBy(qChallenge.idx.desc())
                 .fetch();
     }
 }

--- a/src/main/java/com/challenger/challengerbe/modules/challenge/repository/impl/ChallengeUserCtRepositoryImpl.java
+++ b/src/main/java/com/challenger/challengerbe/modules/challenge/repository/impl/ChallengeUserCtRepositoryImpl.java
@@ -13,9 +13,12 @@ import com.challenger.challengerbe.modules.challenge.dto.ChallengeUserDto;
 import com.challenger.challengerbe.modules.challenge.repository.ChallengeUserCtRepository;
 import com.challenger.challengerbe.modules.user.domain.QUser;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.DateTemplate;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import io.micrometer.common.util.StringUtils;
 import jakarta.persistence.EntityManager;
@@ -91,16 +94,18 @@ public class ChallengeUserCtRepositoryImpl extends BaseAbstractRepositoryImpl im
                                 qChallenge.successCnt,
                                 qChallenge.title,
                                 qChallenge.remark,
-                                qCmsFile.saveFilePath.concat("/").concat(qCmsFile.saveFileName),
-                                qChallengeUser2.count(),
+                                qCmsFile.idx,
+                                ExpressionUtils.as(
+                                        JPAExpressions.select(qChallengeUser.count())
+                                                .from(qChallengeUser)
+                                                .where(qChallenge.idx.eq(qChallengeUser.challenge.idx).and(qChallengeUser.user.idk.ne(searchDto.getIdk())))
+
+                                        ,"joinCnt"),
                                 qChallenge.createDate,
                                 qChallenge.modifyDate
                         )
                 )
         ).from(qChallengeUser)
-                .leftJoin(qChallengeUser2).on(qChallengeUser2.challenge.idx.eq(qChallenge.idx).and(
-                        qChallengeUser2.user.idk.ne(searchDto.getIdk())
-                ))
                 .innerJoin(qChallenge).on(qChallengeUser.challenge.idx.eq(qChallenge.idx))
                 .innerJoin(qUser).on(qChallengeUser.user.idk.eq(qUser.idk))
                 .leftJoin(qCmsFile)
@@ -139,16 +144,18 @@ public class ChallengeUserCtRepositoryImpl extends BaseAbstractRepositoryImpl im
                                         qChallenge.successCnt,
                                         qChallenge.title,
                                         qChallenge.remark,
-                                        qCmsFile.saveFilePath.concat("/").concat(qCmsFile.saveFileName),
-                                        qChallengeUser2.count(),
+                                        qCmsFile.idx,
+                                        ExpressionUtils.as(
+                                                JPAExpressions.select(qChallengeUser.count())
+                                                        .from(qChallengeUser)
+                                                        .where(qChallenge.idx.eq(qChallengeUser.challenge.idx).and(qChallengeUser.user.idk.ne(searchDto.getIdk())))
+
+                                                ,"joinCnt"),
                                         qChallenge.createDate,
                                         qChallenge.modifyDate
                                 )
                         )
                 ).from(qChallengeUser)
-                .leftJoin(qChallengeUser2).on(qChallengeUser2.challenge.idx.eq(qChallenge.idx).and(
-                        qChallengeUser2.user.idk.ne(searchDto.getIdk())
-                ))
                 .innerJoin(qChallenge).on(qChallengeUser.challenge.idx.eq(qChallenge.idx))
                 .innerJoin(qUser).on(qChallengeUser.user.idk.eq(qUser.idk))
                 .leftJoin(qCmsFile)
@@ -179,6 +186,12 @@ public class ChallengeUserCtRepositoryImpl extends BaseAbstractRepositoryImpl im
                                         qChallenge.successCnt,
                                         qChallenge.title,
                                         qChallenge.remark,
+                                        Expressions.numberTemplate(Long.class,"0") ,
+                                        ExpressionUtils.as(
+                                                JPAExpressions.select(qChallengeUser.count())
+                                                        .from(qChallengeUser)
+                                                        .where(qChallenge.idx.eq(qChallengeUser.challenge.idx).and(qChallengeUser.user.idk.ne(dto.getIdk())))
+                                                ,"joinCnt"),
                                         qChallenge.createDate,
                                         qChallenge.modifyDate
                                 )


### PR DESCRIPTION
챌린지 목록 조회 수정은 섬네일 정보와 참여자 수 처리 쿼리를 수정했습니다.