### PR TITLE
파일 업로드 테스트 및 파일 업로드 어노테이션 생성

### DIFF
--- a/src/main/java/com/challenger/challengerbe/cms/file/CmsFileThreadLocalInterceptor.java
+++ b/src/main/java/com/challenger/challengerbe/cms/file/CmsFileThreadLocalInterceptor.java
@@ -1,9 +1,13 @@
 package com.challenger.challengerbe.cms.file;
 
+import com.challenger.challengerbe.common.annotation.FileUploadAction;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.lang.reflect.Method;
 
 /**
  * packageName    : com.routdoo.dailyroutine.cms.file
@@ -25,8 +29,14 @@ public class CmsFileThreadLocalInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
-        System.out.println("------------------------ cms file support intercepter ----------------------------");
-        CmsFileThreadLocalHolder.setRequest(request);
+        // 어노테이션 FileUploadAction 어노테이션일 경오에만 인터셉터가 타도록 수정
+        if(handler instanceof HandlerMethod handlerMethod) {
+            Method method = handlerMethod.getMethod();
+            if(method.isAnnotationPresent(FileUploadAction.class)){
+                System.out.println("------------------------ cms file support intercepter ----------------------------");
+                CmsFileThreadLocalHolder.setRequest(request);
+            }
+        }
         return true;
     }
 

--- a/src/main/java/com/challenger/challengerbe/common/annotation/FileUploadAction.java
+++ b/src/main/java/com/challenger/challengerbe/common/annotation/FileUploadAction.java
@@ -1,0 +1,22 @@
+package com.challenger.challengerbe.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * packageName    : com.challenger.challengerbe.common.annotation
+ * fileName       : FileUploadAction
+ * author         : rhkdg
+ * date           : 2024-09-15
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-09-15        rhkdg       최초 생성
+ */
+@Target({ElementType.METHOD,ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FileUploadAction {
+}

--- a/src/main/java/com/challenger/challengerbe/modules/challenge/controller/ChallengeApplyController.java
+++ b/src/main/java/com/challenger/challengerbe/modules/challenge/controller/ChallengeApplyController.java
@@ -2,6 +2,7 @@ package com.challenger.challengerbe.modules.challenge.controller;
 
 import com.challenger.challengerbe.auth.login.AuthInfo;
 import com.challenger.challengerbe.common.CommonResponse;
+import com.challenger.challengerbe.common.annotation.FileUploadAction;
 import com.challenger.challengerbe.modules.challenge.dto.*;
 import com.challenger.challengerbe.modules.challenge.service.ChallengeApplyService;
 import com.challenger.challengerbe.modules.challenge.service.ChallengeService;
@@ -119,16 +120,51 @@ public class ChallengeApplyController {
        return new ResponseEntity<>(CommonResponse.resOnlyMessageOf("삭제되었습니다."),HttpStatus.OK);
     }
 
-    @Operation(summary = "챌린지 참여자가 챌린지 항목에 대한 성공 처리")
+    @Operation(summary = "챌린지 참여자가 챌린지 항목에 대한 성공 처리",description = "Multipart-form-data 타입만 지정한 API (원본)")
     @Parameters({
             @Parameter(name = "_file", description = "formData 에서 파일 형식, 파일 이름에 해당 , 파일명은 아무거나 선언가능 _file은 예시"),
             @Parameter(name = "_alt_file", description = " formData에서 String으로 전달,  파일의 비고명 아무거나 선언가능 대신 파일명의 name을 뒤에 그대로 붙여줘야함 _alt{파일name}")
     })
+    @FileUploadAction()
     @PostMapping(value = "/challenge/apply/item/ins",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> insertChallengeApplyItem(
             final @Valid @RequestPart ChallengeUserItemCreateRequest challengeUserItemCreateRequest,
             final @RequestPart(value = "_file", required = false) MultipartFile multipartFile
             ) throws Exception {
+
+        ChallengeUserItemDto dto = ChallengeUserItemDto.createOf(challengeUserItemCreateRequest);
+        challengeApplyService.insertChallengeApplyItem(dto);
+
+        return new ResponseEntity<>(CommonResponse.resOnlyMessageOf("성공하셨습니다."),HttpStatus.OK);
+    }
+
+    @Operation(summary = "챌린지 참여자가 챌린지 항목에 대한 성공 처리", description = "Content-type을 아무것도 지정하지 않는 API")
+    @Parameters({
+            @Parameter(name = "_file", description = "formData 에서 파일 형식, 파일 이름에 해당 , 파일명은 아무거나 선언가능 _file은 예시"),
+            @Parameter(name = "_alt_file", description = " formData에서 String으로 전달,  파일의 비고명 아무거나 선언가능 대신 파일명의 name을 뒤에 그대로 붙여줘야함 _alt{파일name}")
+    })
+    @FileUploadAction()
+    @PostMapping(value = "/challenge/apply/item/v2/ins")
+    public ResponseEntity<?> insertChallengeApplyItemV2(
+            final @Valid @RequestPart ChallengeUserItemCreateRequest challengeUserItemCreateRequest
+    ) throws Exception {
+
+        ChallengeUserItemDto dto = ChallengeUserItemDto.createOf(challengeUserItemCreateRequest);
+        challengeApplyService.insertChallengeApplyItem(dto);
+
+        return new ResponseEntity<>(CommonResponse.resOnlyMessageOf("성공하셨습니다."),HttpStatus.OK);
+    }
+
+    @Operation(summary = "챌린지 참여자가 챌린지 항목에 대한 성공 처리", description = "consumes에 Content-Type을 Multipart-form-data 와 application/json을 둘다 받도록 설정햔 API")
+    @Parameters({
+            @Parameter(name = "_file", description = "formData 에서 파일 형식, 파일 이름에 해당 , 파일명은 아무거나 선언가능 _file은 예시"),
+            @Parameter(name = "_alt_file", description = " formData에서 String으로 전달,  파일의 비고명 아무거나 선언가능 대신 파일명의 name을 뒤에 그대로 붙여줘야함 _alt{파일name}")
+    })
+    @FileUploadAction()
+    @PostMapping(value = "/challenge/apply/item/v3/ins",consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<?> insertChallengeApplyItemV3(
+            final @Valid @RequestPart ChallengeUserItemCreateRequest challengeUserItemCreateRequest
+    ) throws Exception {
 
         ChallengeUserItemDto dto = ChallengeUserItemDto.createOf(challengeUserItemCreateRequest);
         challengeApplyService.insertChallengeApplyItem(dto);

--- a/src/main/java/com/challenger/challengerbe/modules/challenge/controller/ChallengeUserController.java
+++ b/src/main/java/com/challenger/challengerbe/modules/challenge/controller/ChallengeUserController.java
@@ -2,6 +2,7 @@ package com.challenger.challengerbe.modules.challenge.controller;
 
 import com.challenger.challengerbe.auth.login.AuthInfo;
 import com.challenger.challengerbe.common.CommonResponse;
+import com.challenger.challengerbe.common.annotation.FileUploadAction;
 import com.challenger.challengerbe.common.exception.AlreadyExistException;
 import com.challenger.challengerbe.common.exception.AlreadyUseException;
 import com.challenger.challengerbe.modules.challenge.dto.*;
@@ -68,7 +69,7 @@ public class ChallengeUserController {
         return challengeService.selectChallengeDto(challengeDto,token);
     }
 
-    @Operation(summary = "챌린지 등록(항목 포함 일괄 처리)")
+    @Operation(summary = "챌린지 등록(항목 포함 일괄 처리)",description = "Multipart-form-data 타입만 지정한 API (원본)")
     @Parameters({
             @Parameter(name = "_file", description = "formData 에서 파일 형식, 파일 이름에 해당 , 파일명은 아무거나 선언가능 _file은 예시"),
             @Parameter(name = "_alt_file", description = " formData에서 String으로 전달,  파일의 비고명 아무거나 선언가능 대신 파일명의 name을 뒤에 그대로 붙여줘야함 _alt{파일name}")
@@ -77,10 +78,50 @@ public class ChallengeUserController {
             @ApiResponse(responseCode = "200", description = "등록 완료"),
             @ApiResponse(responseCode = "400", description = "등록 오류 발생")
     })
+    @FileUploadAction()
     @PostMapping(value="/challenge/ins", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> insertChallenge(final @Valid @RequestPart ChallengeCreateRequest challengeCreateRequest,
-                                             final @RequestPart(value = "_file", required = false) MultipartFile multipartFile,
                                              @AuthInfo String token) throws Exception {
+        ChallengeDto challengeDto = ChallengeDto.createof(challengeCreateRequest);
+        challengeDto.setIdk(token);
+        challengeService.insertChallenge(challengeDto);
+
+        return new ResponseEntity<>(CommonResponse.resOnlyMessageOf("등록 되었습니다."),HttpStatus.OK);
+    }
+
+    @Operation(summary = "챌린지 등록(항목 포함 일괄 처리) v2", description = "Content-type을 아무것도 지정하지 않는 API")
+    @Parameters({
+            @Parameter(name = "_file", description = "formData 에서 파일 형식, 파일 이름에 해당 , 파일명은 아무거나 선언가능 _file은 예시"),
+            @Parameter(name = "_alt_file", description = " formData에서 String으로 전달,  파일의 비고명 아무거나 선언가능 대신 파일명의 name을 뒤에 그대로 붙여줘야함 _alt{파일name}")
+    })
+    @ApiResponses(value={
+            @ApiResponse(responseCode = "200", description = "등록 완료"),
+            @ApiResponse(responseCode = "400", description = "등록 오류 발생")
+    })
+    @FileUploadAction()
+    @PostMapping(value="/challenge/v2/ins")
+    public ResponseEntity<?> insertChallengeV2(final @Valid @RequestPart ChallengeCreateRequest challengeCreateRequest,
+                                             @AuthInfo String token) throws Exception {
+        ChallengeDto challengeDto = ChallengeDto.createof(challengeCreateRequest);
+        challengeDto.setIdk(token);
+        challengeService.insertChallenge(challengeDto);
+
+        return new ResponseEntity<>(CommonResponse.resOnlyMessageOf("등록 되었습니다."),HttpStatus.OK);
+    }
+
+    @Operation(summary = "챌린지 등록(항목 포함 일괄 처리) v3", description = "consumes에 Content-Type을 Multipart-form-data 와 application/json을 둘다 받도록 설정햔 API")
+    @Parameters({
+            @Parameter(name = "_file", description = "formData 에서 파일 형식, 파일 이름에 해당 , 파일명은 아무거나 선언가능 _file은 예시"),
+            @Parameter(name = "_alt_file", description = " formData에서 String으로 전달,  파일의 비고명 아무거나 선언가능 대신 파일명의 name을 뒤에 그대로 붙여줘야함 _alt{파일name}")
+    })
+    @ApiResponses(value={
+            @ApiResponse(responseCode = "200", description = "등록 완료"),
+            @ApiResponse(responseCode = "400", description = "등록 오류 발생")
+    })
+    @FileUploadAction()
+    @PostMapping(value="/challenge/v3/ins", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<?> insertChallengeV3(final @Valid @RequestPart ChallengeCreateRequest challengeCreateRequest,
+                                               @AuthInfo String token) throws Exception {
         ChallengeDto challengeDto = ChallengeDto.createof(challengeCreateRequest);
         challengeDto.setIdk(token);
         challengeService.insertChallenge(challengeDto);

--- a/src/main/java/com/challenger/challengerbe/modules/question/controller/QuestionController.java
+++ b/src/main/java/com/challenger/challengerbe/modules/question/controller/QuestionController.java
@@ -2,6 +2,7 @@ package com.challenger.challengerbe.modules.question.controller;
 
 import com.challenger.challengerbe.auth.login.AuthInfo;
 import com.challenger.challengerbe.common.CommonResponse;
+import com.challenger.challengerbe.common.annotation.FileUploadAction;
 import com.challenger.challengerbe.modules.question.dto.QuestionCreateRequest;
 import com.challenger.challengerbe.modules.question.dto.QuestionDeleteRequest;
 import com.challenger.challengerbe.modules.question.dto.QuestionDto;
@@ -70,6 +71,7 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "등록완료"),
             @ApiResponse(responseCode = "400", description = "등록시 오류 발생")
     })
+    @FileUploadAction()
     @PostMapping(value="", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> createQuestion(@Valid @RequestPart QuestionCreateRequest request,
             @RequestPart(value = "_file",required = false) MultipartFile multipartFile


### PR DESCRIPTION
1. 파일 업로드같은 경우 프론트에서 전송이 안되는 이슈가 있어 여러 API로 구축하여 테스트하기 위함
2. 파일 업로드 전용 어노테이션을 설정하여, 어노테이션이 설정 된 경우에만 인터셉터에서 파일 등록되도록 처리