### PR TITLE
파일 업로드 처리 리팩토링 진행

### DIFF
--- a/src/main/java/com/challenger/challengerbe/cms/file/CmsFileThreadLocalInterceptor.java
+++ b/src/main/java/com/challenger/challengerbe/cms/file/CmsFileThreadLocalInterceptor.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import java.lang.reflect.Method;

--- a/src/main/java/com/challenger/challengerbe/modules/challenge/controller/ChallengeUserController.java
+++ b/src/main/java/com/challenger/challengerbe/modules/challenge/controller/ChallengeUserController.java
@@ -3,7 +3,6 @@ package com.challenger.challengerbe.modules.challenge.controller;
 import com.challenger.challengerbe.auth.login.AuthInfo;
 import com.challenger.challengerbe.common.CommonResponse;
 import com.challenger.challengerbe.common.annotation.FileUploadAction;
-import com.challenger.challengerbe.common.exception.AlreadyExistException;
 import com.challenger.challengerbe.common.exception.AlreadyUseException;
 import com.challenger.challengerbe.modules.challenge.dto.*;
 import com.challenger.challengerbe.modules.challenge.service.ChallengeApplyService;


### PR DESCRIPTION
기존 클라이언트에서 multipart-formdata로 전달할 경우 파일은 저장안되는 현상이 있었던 부분에 대하여 수정 작업 진행

저희 백엔드 서버는 MultipartHttpServletRequest로 처리되도록 인터셉터를 지정하였고 cmsFileService에서 처리되도록 cms를 구축하였습니다. 

클라이언트에서 multipart-formdata로 전송할 경우 json 타입과 file 타입을 formdata에 담아 전달하게 되는데

( MultipartHttpServletRequest )multirequest.getMultiFileMap() 안에 파일만이 있어야한다고 생각했지만, 확인 결과 json 타입과 파일 타입 모두 들어가 있는 것을 확인하였습니다.

그래서 파일 등록 시 파일 확장명을 체크하는 validator 단계에서 에러가 발생하게 되었습니다.
이러한 부분을 해결하기 위해 ContentType이 application인 경우를 제외하고 파일 정보만 추출할 수 있는 필터 기능이 추가적으로 작업이 되어야 정상적으로 등록이 됩니다. 이러한 부분을 수정하여 반영하였습니다.